### PR TITLE
Victor/client facing message on failed json decode

### DIFF
--- a/graphql/http.go
+++ b/graphql/http.go
@@ -64,8 +64,8 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var params httpPostBody
-	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-		writeResponse(nil, err)
+	if json.NewDecoder(r.Body).Decode(&params) != nil {
+		writeResponse(nil, errors.New("request must has a body with valid JSON structure"))
 		return
 	}
 

--- a/graphql/http.go
+++ b/graphql/http.go
@@ -47,8 +47,10 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-
-		http.Error(w, string(responseJSON), http.StatusOK)
+		if w.Header().Get("Content-Type") == "" {
+			w.Header().Set("Content-Type", "application/json")
+		}
+		w.Write(responseJSON)
 	}
 
 	if r.Method != "POST" {

--- a/graphql/http_test.go
+++ b/graphql/http_test.go
@@ -41,7 +41,7 @@ func TestHTTPMustPost(t *testing.T) {
 		t.Errorf("expected 200, but received %d", rr.Code)
 	}
 
-	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"request must be a POST\"]}\n"); diff != "" {
+	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"request must be a POST\"]}"); diff != "" {
 		t.Errorf("expected response to match, but received %s", diff)
 	}
 }
@@ -58,7 +58,7 @@ func TestHTTPParseQuery(t *testing.T) {
 		t.Errorf("expected 200, but received %d", rr.Code)
 	}
 
-	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"request must include a query\"]}\n"); diff != "" {
+	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"request must include a query\"]}"); diff != "" {
 		t.Errorf("expected response to match, but received %s", diff)
 	}
 }
@@ -75,7 +75,7 @@ func TestHTTPMustHaveQuery(t *testing.T) {
 		t.Errorf("expected 200, but received %d", rr.Code)
 	}
 
-	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"must have a single query\"]}\n"); diff != "" {
+	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"must have a single query\"]}"); diff != "" {
 		t.Errorf("expected response to match, but received %s", diff)
 	}
 }
@@ -92,7 +92,24 @@ func TestHTTPSuccess(t *testing.T) {
 		t.Errorf("expected 200, but received %d", rr.Code)
 	}
 
-	if diff := pretty.Compare(rr.Body.String(), "{\"data\":{\"mirror\":-1},\"errors\":null}\n"); diff != "" {
+	if diff := pretty.Compare(rr.Body.String(), "{\"data\":{\"mirror\":-1},\"errors\":null}"); diff != "" {
+		t.Errorf("expected response to match, but received %s", diff)
+	}
+}
+
+func TestHTTPContentType(t *testing.T) {
+	req, err := http.NewRequest("POST", "/graphql", strings.NewReader(`{"query": "query TestQuery($value: int64) { mirror(value: $value) }", "variables": { "value": 1 }}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := testHTTPRequest(req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, but received %d", rr.Code)
+	}
+
+	if diff := pretty.Compare(rr.HeaderMap.Get("Content-Type"), "application/json"); diff != "" {
 		t.Errorf("expected response to match, but received %s", diff)
 	}
 }


### PR DESCRIPTION
I would like to change error message, that occurs when decoding of request body is failed. It returns not useful message and it is not clearly enough to the client what happened. It's not a big problem, but I think we should have a general message here, that clearly says provided request data is not correct.
Examples, how it looks now:
- `{"data":null,"errors":["EOF"]}`
- `{"data":null,"errors":["json: cannot unmarshal object into Go struct field httpPostBody.query of type string"]}`
- `{"data":null,"errors":["invalid character 'v' after object key:value pair"]}`

How it would be after merging the PR:
- `{"data":null,"errors":["request must has a body with valid JSON structure"]}`

My main reason, why it should be done: correct error message will directly point clients to look on their request, instead of contacting GraphQL developers because "their stuff does not work as expected".