### PR TITLE
Add more useful description of client input errors

### DIFF
--- a/graphql/http_test.go
+++ b/graphql/http_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -41,7 +42,23 @@ func TestHTTPMustPost(t *testing.T) {
 		t.Errorf("expected 200, but received %d", rr.Code)
 	}
 
-	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"request must be a POST\"]}"); diff != "" {
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	errors := resp["errors"].([]interface{})
+
+	if len(errors) == 0 {
+		t.Fatal("errors array is empty, when they are expected")
+	} else if len(errors) != 1 {
+		t.Fatal("errors has more than one value")
+	}
+	message := errors[0].(map[string]interface{})["message"]
+	if message == nil {
+		t.Error("message is not present, when it expected")
+		return
+	}
+	if diff := pretty.Compare(message, "request must be a POST"); diff != "" {
 		t.Errorf("expected response to match, but received %s", diff)
 	}
 }
@@ -58,7 +75,22 @@ func TestHTTPParseQuery(t *testing.T) {
 		t.Errorf("expected 200, but received %d", rr.Code)
 	}
 
-	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"request must include a query\"]}"); diff != "" {
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	errors := resp["errors"].([]interface{})
+
+	if len(errors) == 0 {
+		t.Fatal("errors array is empty, when they are expected")
+	} else if len(errors) != 1 {
+		t.Fatal("errors has more than one value")
+	}
+	message := errors[0].(map[string]interface{})["message"]
+	if message == nil {
+		t.Error("message is not present, when it expected")
+	}
+	if diff := pretty.Compare(message, "request must include a query"); diff != "" {
 		t.Errorf("expected response to match, but received %s", diff)
 	}
 }
@@ -74,8 +106,22 @@ func TestHTTPMustHaveQuery(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Errorf("expected 200, but received %d", rr.Code)
 	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	errors := resp["errors"].([]interface{})
 
-	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"must have a single query\"]}"); diff != "" {
+	if len(errors) == 0 {
+		t.Fatal("errors array is empty, when they are expected")
+	} else if len(errors) != 1 {
+		t.Fatal("errors has more than one value")
+	}
+	message := errors[0].(map[string]interface{})["message"]
+	if message == nil {
+		t.Error("message is not present, when it expected")
+	}
+	if diff := pretty.Compare(message, "must have a single query"); diff != "" {
 		t.Errorf("expected response to match, but received %s", diff)
 	}
 }


### PR DESCRIPTION
I would like to add description to errors, that happened in GraphQL because of incorrect client requests. It should be useful for them to understand how they could fix it.