### PR TITLE
Add outsideMiddlewareErrorHandlerFunc

### DIFF
--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -19,6 +19,7 @@ const maxDepth = 100
 
 type errorExtensions struct {
 	Code      string    `json:"code,omitempty"`
+	Message   string    `json:"message,omitempty"`
 	Timestamp time.Time `json:"timestamp,omitempty"`
 }
 
@@ -42,12 +43,16 @@ func newGraphQLErrorRecursive(err error, depth int) graphQLError {
 		gErr.Path = e.Path()
 		return gErr
 	case ClientError:
+		ext := errorExtensions{
+			Code:      e.code,
+			Timestamp: time.Now().UTC(),
+		}
+		if e.description != "" {
+			ext.Message = e.SanitizedError()
+		}
 		return graphQLError{
-			Message: sanitizeError(e).Error(),
-			Extensions: errorExtensions{
-				Code:      e.code,
-				Timestamp: time.Now().UTC(),
-			},
+			Message:    e.Error(),
+			Extensions: ext,
 		}
 	default:
 		return newInternalError(e)

--- a/graphql/middleware.go
+++ b/graphql/middleware.go
@@ -21,6 +21,9 @@ type ComputationOutput struct {
 	Error    error
 }
 
+// outsideMiddlewareErrorHandlerFunc type describes function
+// that will be executed in case if error happens outside processing of MiddlewareFunc
+type outsideMiddlewareErrorHandlerFunc func(err error)
 type MiddlewareFunc func(input *ComputationInput, next MiddlewareNextFunc) *ComputationOutput
 type MiddlewareNextFunc func(input *ComputationInput) *ComputationOutput
 

--- a/graphql/schemabuilder/function_test.go
+++ b/graphql/schemabuilder/function_test.go
@@ -6,17 +6,16 @@ import (
 )
 
 type resolver struct {
-
 }
 
-func (r resolver) Resolve(){}
+func (r resolver) Resolve() {}
 
-func TestPrepareResolveArgs(t *testing.T){
+// TODO: finish it
+func TestPrepareResolveArgs(t *testing.T) {
 	s := Schema{}
 	schema, err := s.Build()
 	if err != nil {
-		fmt.Println(err)
+		t.Errorf("Unexpected error: '%s'", err)
 	}
-
-	s.
+	fmt.Print(schema)
 }

--- a/graphql/server.go
+++ b/graphql/server.go
@@ -107,13 +107,22 @@ type SafeError struct {
 	code    string
 }
 
-type ClientError SafeError
+type ClientError struct {
+	code        string
+	message     string
+	description string
+}
 
 func (e ClientError) Error() string {
 	return e.message
 }
 
+// SanitizedError returns description of the error
+// if description is not set - returns message
 func (e ClientError) SanitizedError() string {
+	if e.description != "" {
+		return e.description
+	}
 	return e.message
 }
 
@@ -131,6 +140,12 @@ func NewError(code string, format string, a ...interface{}) error {
 
 func NewClientError(format string, a ...interface{}) error {
 	return ClientError{message: fmt.Sprintf(format, a...)}
+}
+
+// NewClientErrorWithDescription provides setting description field
+// along with message
+func NewClientErrorWithDescription(description string, format string, a ...interface{}) error {
+	return ClientError{message: fmt.Sprintf(format, a...), description: description}
 }
 
 func NewSafeError(format string, a ...interface{}) error {


### PR DESCRIPTION
I would like to add one more handler for processing errors happened outside of processing MiddlewareFunc.
Also, this PR adds new field to errorExtension structure: `message`. Which stands for representing detailed error message.

In case of client error occur during unmarshaling operation, the response of graphql endpoint will be:
`{"data":null,"errors":[{"message":"request must have a valid JSON structure","path":null,"extensions":{"message":"invalid character 'd' after object key:value pair","timestamp":"2019-03-04T15:02:46.617369822Z"}}]}`