### PR TITLE
Remove message from extensions object for client errors

### DIFF
--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -19,7 +19,6 @@ const maxDepth = 100
 
 type errorExtensions struct {
 	Code      string    `json:"code,omitempty"`
-	Message   string    `json:"message,omitempty"`
 	Timestamp time.Time `json:"timestamp,omitempty"`
 }
 
@@ -43,16 +42,12 @@ func newGraphQLErrorRecursive(err error, depth int) graphQLError {
 		gErr.Path = e.Path()
 		return gErr
 	case ClientError:
-		ext := errorExtensions{
-			Code:      e.code,
-			Timestamp: time.Now().UTC(),
-		}
-		if e.description != "" {
-			ext.Message = e.SanitizedError()
-		}
 		return graphQLError{
-			Message:    e.Error(),
-			Extensions: ext,
+			Message: sanitizeError(e).Error(),
+			Extensions: errorExtensions{
+				Code:      e.code,
+				Timestamp: time.Now().UTC(),
+			},
 		}
 	default:
 		return newInternalError(e)

--- a/graphql/http.go
+++ b/graphql/http.go
@@ -82,7 +82,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if h.errorHandler != nil {
 			h.errorHandler(err)
 		}
-		writeResponse(nil, NewClientErrorWithDescription(err.Error(), "request must have a valid JSON structure"))
+		writeResponse(nil, NewClientError("request must have a valid JSON structure"))
 		return
 	}
 

--- a/graphql/server.go
+++ b/graphql/server.go
@@ -107,22 +107,13 @@ type SafeError struct {
 	code    string
 }
 
-type ClientError struct {
-	code        string
-	message     string
-	description string
-}
+type ClientError SafeError
 
 func (e ClientError) Error() string {
 	return e.message
 }
 
-// SanitizedError returns description of the error
-// if description is not set - returns message
 func (e ClientError) SanitizedError() string {
-	if e.description != "" {
-		return e.description
-	}
 	return e.message
 }
 
@@ -140,12 +131,6 @@ func NewError(code string, format string, a ...interface{}) error {
 
 func NewClientError(format string, a ...interface{}) error {
 	return ClientError{message: fmt.Sprintf(format, a...)}
-}
-
-// NewClientErrorWithDescription provides setting description field
-// along with message
-func NewClientErrorWithDescription(description string, format string, a ...interface{}) error {
-	return ClientError{message: fmt.Sprintf(format, a...), description: description}
 }
 
 func NewSafeError(format string, a ...interface{}) error {


### PR DESCRIPTION
As we discussed, we would like to omit setting original message to extensions object of the response. This PR removes extending this object and bypassing original error message.