### PR TITLE
Add ratelimiting based on query duration

### DIFF
--- a/graphql/http.go
+++ b/graphql/http.go
@@ -12,9 +12,11 @@ import (
 	"github.com/satori/go.uuid"
 )
 
+// HTTPHandler creates an http.Handler object with middlewares
 func HTTPHandler(schema *Schema, middlewares ...MiddlewareFunc) http.Handler {
 	return &httpHandler{
 		schema:      schema,
+		ratelimit:   RatelimitHandlerDefault(),
 		middlewares: middlewares,
 	}
 }
@@ -23,58 +25,17 @@ func HTTPHandler(schema *Schema, middlewares ...MiddlewareFunc) http.Handler {
 // errorHandler func which will catch errors happened outside middleware
 func HTTPHandlerWithHooks(schema *Schema, maxRequests int, minRequests int, waitTime time.Duration, errorHandler outsideMiddlewareErrorHandlerFunc, successfulResponseHook responseHook, middlewares ...MiddlewareFunc) http.Handler {
 	return &httpHandler{
-		schema:                  schema,
-		maxRequests:             maxRequests,
-		minRequests:             minRequests,
-		currentMaxRequestsLevel: maxRequests,
-		waitTime:                waitTime,
-		errorHandler:            errorHandler,
-		middlewares:             middlewares,
-		successfulResponseHook:  successfulResponseHook,
+		schema:                 schema,
+		ratelimit:              RatelimitHandler(maxRequests, minRequests, waitTime),
+		errorHandler:           errorHandler,
+		middlewares:            middlewares,
+		successfulResponseHook: successfulResponseHook,
 	}
 }
 
-type endRequestState int
-
-const (
-	maxSimultaneousRequestsDefault int             = 15
-	minSimultaneousRequestsDefault int             = 2
-	waitTimeDefault                time.Duration   = 3 * time.Second
-	endRequestStateOK              endRequestState = 0
-	endRequestStateError           endRequestState = 1
-	endRequestStateTimedOut        endRequestState = 2
-)
-
-// activeRequest provides structure for request that processing by service
-// stores id, count of simultaneous requests on moment of starting request,
-// date of request start and predicted request duration
-type activeRequest struct {
-	id          uuid.UUID
-	bucketLevel int
-	startedAt   time.Time
-	predictedAt time.Time
-}
-
 type httpHandler struct {
-	// requestsBucket a list of all simultaneous requests
-	requestsBucket []activeRequest
-	// maxRequests the max possible amount of simultaneous requests that will
-	// have service
-	maxRequests int
-	// minRequests the min possible amount of simultaneous requests
-	minRequests int
-	// currentMaxRequestsLevel an amount of simultaneous requests that could be
-	// processed in current situation. This count is depends on timeouted
-	// requests to databases
-	currentMaxRequestsLevel int
-	// predictedDuration a duration that could take current request. Calculation
-	// depends on real duration of previous requests
-	predictedDuration time.Duration
-	// if simultaneous requests of service reach level of
-	// currentMaxRequestsLevel service will wait `waitTime` before repeating
-	// attempt to serve request
-	waitTime               time.Duration
 	schema                 *Schema
+	ratelimit              *RatelimitObject
 	errorHandler           outsideMiddlewareErrorHandlerFunc
 	successfulResponseHook responseHook
 	middlewares            []MiddlewareFunc
@@ -90,101 +51,7 @@ type httpResponse struct {
 	Errors interface{} `json:"errors"`
 }
 
-// newRequest creates activeRequest object. Method grants that request will be
-// served
-func (h *httpHandler) newRequest() (uuid.UUID, error) {
-	connID := uuid.NewV4()
-	predictedAt := time.Now().Add(h.predictedDuration)
-	h.requestsBucket = append(h.requestsBucket, activeRequest{
-		id:          connID,
-		bucketLevel: len(h.requestsBucket) + 1,
-		startedAt:   time.Now(),
-		predictedAt: predictedAt,
-	})
-	return connID, nil
-}
-
-// serveRequest decides put request into work or not. If amount of simultaneous
-// requests is more than allowed (`currentMaxRequestsLevel` level), method will
-// wait for up to `httpHandler.waitTime` and repeat attempt to start request. If
-// request started: returns UUID of request, otherwise returns empty UUID and
-// error
-func (h *httpHandler) serveRequest(isInitial bool) (uuid.UUID, error) {
-	if len(h.requestsBucket) < h.currentMaxRequestsLevel {
-		return h.newRequest()
-	}
-	if isInitial && h.predictedDuration <= h.waitTime {
-		time.Sleep(h.predictedDuration)
-		return h.serveRequest(false)
-	}
-	return uuid.Nil, NewClientError("limit is reached, please try again later")
-}
-
-// endRequest finishes request and removes it from the list of simultaneous
-// requests. Method adjustes `predictedDuration` value based on `endState` code.
-func (h *httpHandler) endRequest(connID uuid.UUID, endState endRequestState) {
-	if connID == uuid.Nil {
-		return
-	}
-	var connection activeRequest
-	for i, conn := range h.requestsBucket {
-		if conn.id == connID {
-			connection = conn
-			h.requestsBucket = append(h.requestsBucket[:i], h.requestsBucket[i+1:]...)
-			break
-		}
-	}
-	// we do not want update prediction if endState == endRequestStateError or
-	// somehow connection was not found
-	if connection.id == uuid.Nil || endState == endRequestStateError {
-		return
-	}
-	// if connection was timeouted, we would like to decrease
-	// currentMaxRequestsLevel or set it to level of simultaneous requests,
-	// which was when request has been accepted
-	if endState == endRequestStateTimedOut {
-		if connection.bucketLevel <= h.minRequests {
-			h.currentMaxRequestsLevel = h.minRequests
-		} else if connection.bucketLevel > h.currentMaxRequestsLevel {
-			h.currentMaxRequestsLevel--
-		} else {
-			h.currentMaxRequestsLevel = connection.bucketLevel
-		}
-	} else if h.currentMaxRequestsLevel < h.maxRequests {
-		// if endState is OK, we would like increment amount of
-		// currentMaxRequestsLevel
-		h.currentMaxRequestsLevel++
-	}
-	elapsedTime := time.Since(connection.startedAt)
-	// if real request time is longer than expected we will update prediction to
-	// the real request time
-	if elapsedTime >= h.predictedDuration {
-		h.predictedDuration = elapsedTime
-	} else {
-		// if real request time is less than expected we decrease it on an half
-		// of difference
-		h.predictedDuration = (elapsedTime + h.predictedDuration) / 2
-	}
-}
-
-func (h *httpHandler) setRatelimitValues() {
-	if h.waitTime == 0 {
-		h.waitTime = waitTimeDefault
-	}
-	if h.predictedDuration == 0 {
-		h.predictedDuration = h.waitTime
-	}
-	if h.maxRequests == 0 {
-		h.maxRequests = maxSimultaneousRequestsDefault
-		h.currentMaxRequestsLevel = maxSimultaneousRequestsDefault
-	}
-	if h.minRequests == 0 {
-		h.minRequests = minSimultaneousRequestsDefault
-	}
-}
-
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	h.setRatelimitValues()
 	writeResponse := func(value interface{}, err error, query *string, connID uuid.UUID) {
 		response := httpResponse{}
 		endStateValue := endRequestStateOK
@@ -198,7 +65,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			response.Data = value
 		}
 
-		h.endRequest(connID, endStateValue)
+		h.ratelimit.EndRequest(connID, endStateValue)
 		responseJSON, err := json.Marshal(response)
 		if err != nil {
 			if h.errorHandler != nil {
@@ -236,7 +103,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	connID, err := h.serveRequest(true)
+	connID, err := h.ratelimit.ServeRequest(true)
 	if err != nil {
 		writeResponse(nil, err, nil, uuid.Nil)
 		return
@@ -288,7 +155,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			} else {
 				// we would like to end request and free from the list of
 				// simultaneous requests
-				h.endRequest(connID, endRequestStateTimedOut)
+				h.ratelimit.EndRequest(connID, endRequestStateTimedOut)
 			}
 			return nil, err
 		}

--- a/graphql/http.go
+++ b/graphql/http.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/reactive"
+	"github.com/satori/go.uuid"
 )
 
 func HTTPHandler(schema *Schema, middlewares ...MiddlewareFunc) http.Handler {
@@ -17,19 +19,61 @@ func HTTPHandler(schema *Schema, middlewares ...MiddlewareFunc) http.Handler {
 	}
 }
 
-// HTTPHandlerWithErrorHandling works as HTTPHandler
-// but in addition provides passing errorHandler func
-// which will catch errors happened outside middleware
-func HTTPHandlerWithHooks(schema *Schema, errorHandler outsideMiddlewareErrorHandlerFunc, successfulResponseHook responseHook, middlewares ...MiddlewareFunc) http.Handler {
+// HTTPHandlerWithHooks works as HTTPHandler but in addition provides passing
+// errorHandler func which will catch errors happened outside middleware
+func HTTPHandlerWithHooks(schema *Schema, maxRequests int, minRequests int, waitTime time.Duration, errorHandler outsideMiddlewareErrorHandlerFunc, successfulResponseHook responseHook, middlewares ...MiddlewareFunc) http.Handler {
 	return &httpHandler{
-		schema:                 schema,
-		errorHandler:           errorHandler,
-		middlewares:            middlewares,
-		successfulResponseHook: successfulResponseHook,
+		schema:                  schema,
+		maxRequests:             maxRequests,
+		minRequests:             minRequests,
+		currentMaxRequestsLevel: maxRequests,
+		waitTime:                waitTime,
+		errorHandler:            errorHandler,
+		middlewares:             middlewares,
+		successfulResponseHook:  successfulResponseHook,
 	}
 }
 
+type endRequestState int
+
+const (
+	maxSimultaneousRequestsDefault int             = 15
+	minSimultaneousRequestsDefault int             = 2
+	waitTimeDefault                time.Duration   = 3 * time.Second
+	endRequestStateOK              endRequestState = 0
+	endRequestStateError           endRequestState = 1
+	endRequestStateTimedOut        endRequestState = 2
+)
+
+// activeRequest provides structure for request that processing by service
+// stores id, count of simultaneous requests on moment of starting request,
+// date of request start and predicted request duration
+type activeRequest struct {
+	id          uuid.UUID
+	bucketLevel int
+	startedAt   time.Time
+	predictedAt time.Time
+}
+
 type httpHandler struct {
+	// requestsBucket a list of all simultaneous requests
+	requestsBucket []activeRequest
+	// maxRequests the max possible amount of simultaneous requests that will
+	// have service
+	maxRequests int
+	// minRequests the min possible amount of simultaneous requests
+	minRequests int
+	// currentMaxRequestsLevel an amount of simultaneous requests that could be
+	// processed in current situation. This count is depends on timeouted
+	// requests to databases
+	currentMaxRequestsLevel int
+	// predictedDuration a duration that could take current request. Calculation
+	// depends on real duration of previous requests
+	predictedDuration time.Duration
+	// if simultaneous requests of service reach level of
+	// currentMaxRequestsLevel service will wait `waitTime` before repeating
+	// attempt to serve request
+	waitTime               time.Duration
 	schema                 *Schema
 	errorHandler           outsideMiddlewareErrorHandlerFunc
 	successfulResponseHook responseHook
@@ -46,10 +90,106 @@ type httpResponse struct {
 	Errors interface{} `json:"errors"`
 }
 
+// newRequest creates activeRequest object. Method grants that request will be
+// served
+func (h *httpHandler) newRequest() (uuid.UUID, error) {
+	connID := uuid.NewV4()
+	predictedAt := time.Now().Add(h.predictedDuration)
+	h.requestsBucket = append(h.requestsBucket, activeRequest{
+		id:          connID,
+		bucketLevel: len(h.requestsBucket) + 1,
+		startedAt:   time.Now(),
+		predictedAt: predictedAt,
+	})
+	return connID, nil
+}
+
+// serveRequest decides put request into work or not. If amount of simultaneous
+// requests is more than allowed (`currentMaxRequestsLevel` level), method will
+// wait for up to `httpHandler.waitTime` and repeat attempt to start request. If
+// request started: returns UUID of request, otherwise returns empty UUID and
+// error
+func (h *httpHandler) serveRequest(isInitial bool) (uuid.UUID, error) {
+	if len(h.requestsBucket) < h.currentMaxRequestsLevel {
+		return h.newRequest()
+	}
+	if isInitial && h.predictedDuration <= h.waitTime {
+		time.Sleep(h.predictedDuration)
+		return h.serveRequest(false)
+	}
+	return uuid.Nil, NewClientError("limit is reached, please try again later")
+}
+
+// endRequest finishes request and removes it from the list of simultaneous
+// requests. Method adjustes `predictedDuration` value based on `endState` code.
+func (h *httpHandler) endRequest(connID uuid.UUID, endState endRequestState) {
+	if connID == uuid.Nil {
+		return
+	}
+	var connection activeRequest
+	for i, conn := range h.requestsBucket {
+		if conn.id == connID {
+			connection = conn
+			h.requestsBucket = append(h.requestsBucket[:i], h.requestsBucket[i+1:]...)
+			break
+		}
+	}
+	// we do not want update prediction if endState == endRequestStateError or
+	// somehow connection was not found
+	if connection.id == uuid.Nil || endState == endRequestStateError {
+		return
+	}
+	// if connection was timeouted, we would like to decrease
+	// currentMaxRequestsLevel or set it to level of simultaneous requests,
+	// which was when request has been accepted
+	if endState == endRequestStateTimedOut {
+		if connection.bucketLevel <= h.minRequests {
+			h.currentMaxRequestsLevel = h.minRequests
+		} else if connection.bucketLevel > h.currentMaxRequestsLevel {
+			h.currentMaxRequestsLevel--
+		} else {
+			h.currentMaxRequestsLevel = connection.bucketLevel
+		}
+	} else if h.currentMaxRequestsLevel < h.maxRequests {
+		// if endState is OK, we would like increment amount of
+		// currentMaxRequestsLevel
+		h.currentMaxRequestsLevel++
+	}
+	elapsedTime := time.Since(connection.startedAt)
+	// if real request time is longer than expected we will update prediction to
+	// the real request time
+	if elapsedTime >= h.predictedDuration {
+		h.predictedDuration = elapsedTime
+	} else {
+		// if real request time is less than expected we decrease it on an half
+		// of difference
+		h.predictedDuration = (elapsedTime + h.predictedDuration) / 2
+	}
+}
+
+func (h *httpHandler) setRatelimitValues() {
+	if h.waitTime == 0 {
+		h.waitTime = waitTimeDefault
+	}
+	if h.predictedDuration == 0 {
+		h.predictedDuration = h.waitTime
+	}
+	if h.maxRequests == 0 {
+		h.maxRequests = maxSimultaneousRequestsDefault
+		h.currentMaxRequestsLevel = maxSimultaneousRequestsDefault
+	}
+	if h.minRequests == 0 {
+		h.minRequests = minSimultaneousRequestsDefault
+	}
+}
+
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	writeResponse := func(value interface{}, err error, query *string) {
+	h.setRatelimitValues()
+	writeResponse := func(value interface{}, err error, query *string, connID uuid.UUID) {
 		response := httpResponse{}
+		endStateValue := endRequestStateOK
 		if err != nil {
+			endStateValue = endRequestStateError
 			if h.errorHandler != nil {
 				h.errorHandler(flattenError(err, 0), query)
 			}
@@ -58,6 +198,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			response.Data = value
 		}
 
+		h.endRequest(connID, endStateValue)
 		responseJSON, err := json.Marshal(response)
 		if err != nil {
 			if h.errorHandler != nil {
@@ -77,12 +218,12 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method != "POST" {
-		writeResponse(nil, NewClientError("request must be a POST"), nil)
+		writeResponse(nil, NewClientError("request must be a POST"), nil, uuid.Nil)
 		return
 	}
 
 	if r.Body == nil {
-		writeResponse(nil, NewClientError("request must include a query"), nil)
+		writeResponse(nil, NewClientError("request must include a query"), nil, uuid.Nil)
 		return
 	}
 
@@ -91,13 +232,19 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if h.errorHandler != nil {
 			h.errorHandler(err, nil)
 		}
-		writeResponse(nil, NewClientError("request must have a valid JSON structure"), nil)
+		writeResponse(nil, NewClientError("request must have a valid JSON structure"), nil, uuid.Nil)
+		return
+	}
+
+	connID, err := h.serveRequest(true)
+	if err != nil {
+		writeResponse(nil, err, nil, uuid.Nil)
 		return
 	}
 
 	query, err := Parse(params.Query, params.Variables)
 	if err != nil {
-		writeResponse(nil, err, &params.Query)
+		writeResponse(nil, err, &params.Query, connID)
 		return
 	}
 
@@ -106,7 +253,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		schema = h.schema.Mutation
 	}
 	if err := PrepareQuery(schema, query.SelectionSet); err != nil {
-		writeResponse(nil, err, &params.Query)
+		writeResponse(nil, err, &params.Query, connID)
 		return
 	}
 
@@ -137,12 +284,16 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		if err != nil {
 			if ErrorCause(err) != context.Canceled {
-				writeResponse(nil, err, &params.Query)
+				writeResponse(nil, err, &params.Query, connID)
+			} else {
+				// we would like to end request and free from the list of
+				// simultaneous requests
+				h.endRequest(connID, endRequestStateTimedOut)
 			}
 			return nil, err
 		}
 
-		writeResponse(current, nil, nil)
+		writeResponse(current, nil, nil, connID)
 		return nil, nil
 	}, DefaultMinRerunInterval)
 

--- a/graphql/http.go
+++ b/graphql/http.go
@@ -103,7 +103,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	connID, err := h.ratelimit.ServeRequest(true)
+	connID, err := h.ratelimit.ServeRequest()
 	if err != nil {
 		writeResponse(nil, err, nil, uuid.Nil)
 		return

--- a/graphql/middleware.go
+++ b/graphql/middleware.go
@@ -7,6 +7,8 @@ import (
 type ComputationInput struct {
 	Id                   string
 	Query                string
+	RequestsCount        int
+	RequestsLimit        int
 	ParsedQuery          *Query
 	Variables            map[string]interface{}
 	Ctx                  context.Context

--- a/graphql/ratelimit.go
+++ b/graphql/ratelimit.go
@@ -1,0 +1,172 @@
+package graphql
+
+import (
+	"sync"
+	"time"
+
+	"github.com/satori/go.uuid"
+)
+
+type endRequestState int
+
+const (
+	maxSimultaneousRequestsDefault int             = 15
+	minSimultaneousRequestsDefault int             = 2
+	waitTimeDefault                time.Duration   = 3 * time.Second
+	endRequestStateOK              endRequestState = 0
+	endRequestStateError           endRequestState = 1
+	endRequestStateTimedOut        endRequestState = 2
+)
+
+// RatelimitObject represents structure of ratelimit object
+type RatelimitObject struct {
+	// requestsBucket a list of all simultaneous requests
+	requestsBucket []activeRequest
+	// maxRequests the max possible amount of simultaneous requests that will
+	// have service
+	maxRequests int
+	// minRequests the min possible amount of simultaneous requests
+	minRequests int
+	// currentMaxRequestsLevel an amount of simultaneous requests that could be
+	// processed in current situation. This count is depends on timeouted
+	// requests to databases
+	currentMaxRequestsLevel int
+	// predictedDuration a duration that could take current request. Calculation
+	// depends on real duration of previous requests
+	predictedDuration time.Duration
+	// if simultaneous requests of service reach level of
+	// currentMaxRequestsLevel service will wait `waitTime` before repeating
+	// attempt to serve request
+	waitTime time.Duration
+	mux      sync.Mutex
+}
+
+// activeRequest provides structure for request that processing by service
+// stores id, count of simultaneous requests on moment of starting request,
+// date of request start and predicted request duration
+type activeRequest struct {
+	id          uuid.UUID
+	bucketLevel int
+	startedAt   time.Time
+	predictedAt time.Time
+}
+
+// RatelimitHandlerDefault creates ratelimit object with empty values
+func RatelimitHandlerDefault() *RatelimitObject {
+	rObj := &RatelimitObject{}
+	return rObj.initiate()
+}
+
+// RatelimitHandler creates ratelimit struct object
+func RatelimitHandler(maxRequests int, minRequests int, waitTime time.Duration) *RatelimitObject {
+	rObj := RatelimitObject{
+		maxRequests:             maxRequests,
+		minRequests:             minRequests,
+		currentMaxRequestsLevel: maxRequests,
+		waitTime:                waitTime,
+		predictedDuration:       waitTime,
+	}
+	return rObj.initiate()
+}
+
+// initiate helps initialize ratelimitObject with default values
+func (rObj *RatelimitObject) initiate() *RatelimitObject {
+	rObj.mux.Lock()
+	if rObj.waitTime == 0 {
+		rObj.waitTime = waitTimeDefault
+	}
+	if rObj.predictedDuration == 0 {
+		rObj.predictedDuration = rObj.waitTime
+	}
+	if rObj.maxRequests == 0 {
+		rObj.maxRequests = maxSimultaneousRequestsDefault
+		rObj.currentMaxRequestsLevel = maxSimultaneousRequestsDefault
+	}
+	if rObj.minRequests == 0 {
+		rObj.minRequests = minSimultaneousRequestsDefault
+	}
+	rObj.mux.Unlock()
+	return rObj
+}
+
+// newRequest creates activeRequest object. Method grants that request will be
+// served
+func (rObj *RatelimitObject) newRequest() (uuid.UUID, error) {
+	connID := uuid.NewV4()
+	predictedAt := time.Now().Add(rObj.predictedDuration)
+	rObj.mux.Lock()
+	rObj.requestsBucket = append(rObj.requestsBucket, activeRequest{
+		id:          connID,
+		bucketLevel: len(rObj.requestsBucket) + 1,
+		startedAt:   time.Now(),
+		predictedAt: predictedAt,
+	})
+	rObj.mux.Unlock()
+	return connID, nil
+}
+
+// ServeRequest decides put request into work or not. If amount of simultaneous
+// requests is more than allowed (`currentMaxRequestsLevel` level), method will
+// wait for up to `httpHandler.waitTime` and repeat attempt to start request. If
+// request started: returns UUID of request, otherwise returns empty UUID and
+// error
+func (rObj *RatelimitObject) ServeRequest(isInitial bool) (uuid.UUID, error) {
+	if len(rObj.requestsBucket) < rObj.currentMaxRequestsLevel {
+		return rObj.newRequest()
+	}
+	if isInitial && rObj.predictedDuration <= rObj.waitTime {
+		time.Sleep(rObj.predictedDuration)
+		return rObj.ServeRequest(false)
+	}
+	return uuid.Nil, NewClientError("limit is reached, please try again later")
+}
+
+// EndRequest finishes request and removes it from the list of simultaneous
+// requests. Method adjustes `predictedDuration` value based on `endState` code.
+func (rObj *RatelimitObject) EndRequest(connID uuid.UUID, endState endRequestState) {
+	if connID == uuid.Nil {
+		return
+	}
+	rObj.mux.Lock()
+	var connection activeRequest
+	for i, conn := range rObj.requestsBucket {
+		if conn.id == connID {
+			connection = conn
+			rObj.requestsBucket = append(rObj.requestsBucket[:i], rObj.requestsBucket[i+1:]...)
+			break
+		}
+	}
+	// we do not want update prediction if endState == endRequestStateError or
+	// somehow connection was not found
+	if connection.id == uuid.Nil || endState == endRequestStateError {
+		rObj.mux.Unlock()
+		return
+	}
+	// if connection was timeouted, we would like to decrease
+	// currentMaxRequestsLevel or set it to level of simultaneous requests,
+	// which was when request has been accepted
+	if endState == endRequestStateTimedOut {
+		if connection.bucketLevel <= rObj.minRequests {
+			rObj.currentMaxRequestsLevel = rObj.minRequests
+		} else if connection.bucketLevel > rObj.currentMaxRequestsLevel {
+			rObj.currentMaxRequestsLevel--
+		} else {
+			rObj.currentMaxRequestsLevel = connection.bucketLevel
+		}
+	} else if rObj.currentMaxRequestsLevel < rObj.maxRequests {
+		// if endState is OK, we would like increment amount of
+		// currentMaxRequestsLevel
+		rObj.currentMaxRequestsLevel++
+	}
+	elapsedTime := time.Since(connection.startedAt)
+	// if real request time is longer than expected we will update prediction to
+	// the real request time
+	if elapsedTime >= rObj.predictedDuration {
+		rObj.predictedDuration = elapsedTime
+	} else {
+		// if real request time is less than expected we decrease it on an half
+		// of difference
+		rObj.predictedDuration -= (elapsedTime + rObj.predictedDuration) / 2
+	}
+	rObj.mux.Unlock()
+}

--- a/graphql/ratelimit.go
+++ b/graphql/ratelimit.go
@@ -3,8 +3,6 @@ package graphql
 import (
 	"sync"
 	"time"
-
-	"github.com/satori/go.uuid"
 )
 
 type endRequestState int
@@ -15,13 +13,13 @@ const (
 	waitTimeDefault                time.Duration   = 3 * time.Second
 	endRequestStateOK              endRequestState = 0
 	endRequestStateError           endRequestState = 1
-	endRequestStateTimedOut        endRequestState = 2
+	endRequestStateCanceled        endRequestState = 2
 )
 
 // RatelimitObject represents structure of ratelimit object
 type RatelimitObject struct {
 	// requestsBucket a list of all simultaneous requests
-	requestsBucket map[uuid.UUID]activeRequest
+	activeRequestsCount int
 	// maxRequests the max possible amount of simultaneous requests that will
 	// have service
 	maxRequests int
@@ -35,24 +33,23 @@ type RatelimitObject struct {
 	// depends on real duration of previous requests
 	predictedDuration time.Duration
 	// if simultaneous requests of service reach level of
-	// currentMaxRequestsLevel service will wait `waitTime` before repeating
-	// attempt to serve request
+	// currentMaxRequestsLevel service will wait up to `waitTime` before
+	// repeating attempt to serve request
 	waitTime time.Duration
 	mux      sync.Mutex
 }
 
-// activeRequest provides structure for request that processing by service
+// ActiveRequest provides structure for request that processing by service
 // stores id, count of simultaneous requests on moment of starting request,
 // date of request start and predicted request duration
-type activeRequest struct {
-	bucketLevel int
+type ActiveRequest struct {
 	startedAt   time.Time
 	predictedAt time.Time
 }
 
 // RatelimitHandlerDefault creates ratelimit object with empty values
 func RatelimitHandlerDefault() *RatelimitObject {
-	rObj := &RatelimitObject{}
+	rObj := RatelimitObject{}
 	return rObj.initiate()
 }
 
@@ -68,9 +65,84 @@ func RatelimitHandler(maxRequests int, minRequests int, waitTime time.Duration) 
 	return rObj.initiate()
 }
 
+// GetSimultaneousRequestsCount returns number of simultaneous requests
+func (rObj *RatelimitObject) GetSimultaneousRequestsCount() int {
+	rObj.mux.Lock()
+	defer rObj.mux.Unlock()
+	return rObj.activeRequestsCount
+}
+
+// GetActualRequestsLimit returns number of simultaneous requests
+func (rObj *RatelimitObject) GetActualRequestsLimit() int {
+	rObj.mux.Lock()
+	defer rObj.mux.Unlock()
+	return rObj.currentMaxRequestsLevel
+}
+
+// ServeRequest decides put request into work or not. If amount of simultaneous
+// requests is more than allowed (`currentMaxRequestsLevel` level), method will
+// wait for up to `RatelimitObject.waitTime` and repeat attempt to start
+// request. If request started: returns pointer to request, otherwise returns
+// nil and error
+func (rObj *RatelimitObject) ServeRequest(isInitial bool) (*ActiveRequest, error) {
+	rObj.mux.Lock()
+	if rObj.activeRequestsCount < rObj.currentMaxRequestsLevel {
+		rObj.mux.Unlock()
+		return rObj.newRequest()
+	}
+	dur := rObj.predictedDuration
+	rObj.mux.Unlock()
+	if isInitial && dur <= rObj.waitTime {
+		time.Sleep(dur)
+		return rObj.ServeRequest(false)
+	}
+	return nil, NewClientError("limit is reached, please try again later")
+}
+
+// EndRequest finishes request and removes it from the list of simultaneous
+// requests. Method adjustes `predictedDuration` value based on `endState` code.
+func (rObj *RatelimitObject) EndRequest(request *ActiveRequest, endState endRequestState) {
+	if request == nil {
+		return
+	}
+	rObj.mux.Lock()
+	rObj.activeRequestsCount--
+	elapsedTime := time.Since(request.startedAt)
+	// if we got an error we should adjust currentMaxRequestsLevel by decreasing
+	// it according spent time on query
+	if endState != endRequestStateOK {
+		if rObj.currentMaxRequestsLevel > rObj.minRequests {
+			if elapsedTime > rObj.predictedDuration || elapsedTime > rObj.waitTime {
+				rObj.currentMaxRequestsLevel -= (rObj.currentMaxRequestsLevel - rObj.minRequests) / 2
+			} else {
+				rObj.currentMaxRequestsLevel--
+			}
+		}
+	} else if rObj.currentMaxRequestsLevel < rObj.maxRequests {
+		// if endState is OK, we would like increment amount of
+		// currentMaxRequestsLevel
+		rObj.currentMaxRequestsLevel++
+	}
+
+	// we do not want update prediction if endState == endRequestStateError
+	if endState == endRequestStateError {
+		rObj.mux.Unlock()
+		return
+	}
+	// if real request time is longer than expected we will update prediction to
+	// the real request time
+	if elapsedTime >= rObj.predictedDuration {
+		rObj.predictedDuration = elapsedTime
+	} else {
+		// if real request time is less than expected we decrease it on an half
+		// of difference
+		rObj.predictedDuration -= (elapsedTime + rObj.predictedDuration) / 2
+	}
+	rObj.mux.Unlock()
+}
+
 // initiate helps initialize ratelimitObject with default values
 func (rObj *RatelimitObject) initiate() *RatelimitObject {
-	rObj.requestsBucket = make(map[uuid.UUID]activeRequest)
 	if rObj.waitTime == 0 {
 		rObj.waitTime = waitTimeDefault
 	}
@@ -89,80 +161,15 @@ func (rObj *RatelimitObject) initiate() *RatelimitObject {
 
 // newRequest creates activeRequest object. Method grants that request will be
 // served
-func (rObj *RatelimitObject) newRequest() (uuid.UUID, error) {
-	connID := uuid.NewV4()
+func (rObj *RatelimitObject) newRequest() (*ActiveRequest, error) {
+	now := time.Now()
 	rObj.mux.Lock()
-	predictedAt := time.Now().Add(rObj.predictedDuration)
-	rObj.requestsBucket[connID] = activeRequest{
-		bucketLevel: len(rObj.requestsBucket) + 1,
-		startedAt:   time.Now(),
+	predictedAt := now.Add(rObj.predictedDuration)
+	rObj.activeRequestsCount++
+	rObj.mux.Unlock()
+	req := ActiveRequest{
+		startedAt:   now,
 		predictedAt: predictedAt,
 	}
-	rObj.mux.Unlock()
-	return connID, nil
-}
-
-// ServeRequest decides put request into work or not. If amount of simultaneous
-// requests is more than allowed (`currentMaxRequestsLevel` level), method will
-// wait for up to `RatelimitObject.waitTime` and repeat attempt to start request. If
-// request started: returns UUID of request, otherwise returns empty UUID and
-// error
-func (rObj *RatelimitObject) ServeRequest() (uuid.UUID, error) {
-	for i := 0; i < 2; i++ {
-		rObj.mux.Lock()
-		if len(rObj.requestsBucket) < rObj.currentMaxRequestsLevel {
-			rObj.mux.Unlock()
-			return rObj.newRequest()
-		}
-		dur := rObj.predictedDuration
-		rObj.mux.Unlock()
-		if dur <= rObj.waitTime {
-			time.Sleep(dur)
-		}
-	}
-	return uuid.Nil, NewClientError("limit is reached, please try again later")
-}
-
-// EndRequest finishes request and removes it from the list of simultaneous
-// requests. Method adjustes `predictedDuration` value based on `endState` code.
-func (rObj *RatelimitObject) EndRequest(connID uuid.UUID, endState endRequestState) {
-	if connID == uuid.Nil {
-		return
-	}
-	rObj.mux.Lock()
-	request, ok := rObj.requestsBucket[connID]
-	delete(rObj.requestsBucket, connID)
-	// we do not want update prediction if endState == endRequestStateError or
-	// somehow connection was not found
-	if !ok || endState == endRequestStateError {
-		rObj.mux.Unlock()
-		return
-	}
-	// if connection was timeouted, we would like to decrease
-	// currentMaxRequestsLevel or set it to level of simultaneous requests,
-	// which was when request has been accepted
-	if endState == endRequestStateTimedOut {
-		if request.bucketLevel <= rObj.minRequests {
-			rObj.currentMaxRequestsLevel = rObj.minRequests
-		} else if request.bucketLevel > rObj.currentMaxRequestsLevel {
-			rObj.currentMaxRequestsLevel--
-		} else {
-			rObj.currentMaxRequestsLevel = request.bucketLevel
-		}
-	} else if rObj.currentMaxRequestsLevel < rObj.maxRequests {
-		// if endState is OK, we would like increment amount of
-		// currentMaxRequestsLevel
-		rObj.currentMaxRequestsLevel++
-	}
-	elapsedTime := time.Since(request.startedAt)
-	// if real request time is longer than expected we will update prediction to
-	// the real request time
-	if elapsedTime >= rObj.predictedDuration {
-		rObj.predictedDuration = elapsedTime
-	} else {
-		// if real request time is less than expected we decrease it on an half
-		// of difference
-		rObj.predictedDuration -= (elapsedTime + rObj.predictedDuration) / 2
-	}
-	rObj.mux.Unlock()
+	return &req, nil
 }

--- a/graphql/ratelimit_test.go
+++ b/graphql/ratelimit_test.go
@@ -3,19 +3,17 @@ package graphql
 import (
 	"testing"
 	"time"
-
-	"github.com/satori/go.uuid"
 )
 
-func addRequest(rObj *RatelimitObject, t *testing.T) uuid.UUID {
-	ID, err := rObj.newRequest()
+func addRequest(rObj *RatelimitObject, t *testing.T) *ActiveRequest {
+	req, err := rObj.newRequest()
 	if err != nil {
 		t.Fatalf("error occured, when it was unexpected: %v", err)
 	}
-	if ID == uuid.Nil {
+	if req == nil {
 		t.Fatal("connection ID should not be nil")
 	}
-	return ID
+	return req
 }
 func TestInitiating(t *testing.T) {
 	rObj := RatelimitHandlerDefault()
@@ -34,28 +32,101 @@ func TestInitiating(t *testing.T) {
 func TestNewRequest(t *testing.T) {
 	rObj := RatelimitHandler(10, 2, time.Duration(10*time.Second))
 	addRequest(rObj, t)
-	if cnt := len(rObj.requestsBucket); cnt != 1 {
+	cnt := rObj.GetSimultaneousRequestsCount()
+	if cnt != 1 {
 		t.Fatalf("requests bucket should has size of 1 element, but %d got", cnt)
 	}
 	addRequest(rObj, t)
-
-	if cnt := len(rObj.requestsBucket); cnt != 2 {
+	cnt = rObj.GetSimultaneousRequestsCount()
+	if cnt != 2 {
 		t.Fatalf("requests bucket should has size of 1 element, but %d got", cnt)
+	}
+}
+
+func TestConcurrentServeRequest(t *testing.T) {
+	rObj := RatelimitHandler(10, 2, time.Duration(10*time.Second))
+	for i := 0; i <= 10; i++ {
+		go rObj.ServeRequest(true)
+	}
+	time.Sleep(100 * time.Millisecond)
+	cnt := rObj.GetSimultaneousRequestsCount()
+	if cnt != 10 {
+		t.Fatalf("requests bucket should has size of 10 elements, but %d got", cnt)
+	}
+}
+
+func TestConcurrentServeRequestAndEndRequest(t *testing.T) {
+	rObj := RatelimitHandler(10, 2, time.Duration(10*time.Second))
+	for i := 0; i <= 9; i++ {
+		go func() {
+			req, _ := rObj.ServeRequest(true)
+			time.Sleep(100 * time.Millisecond)
+			rObj.EndRequest(req, endRequestStateOK)
+		}()
+	}
+	time.Sleep(1000 * time.Millisecond)
+	cnt := rObj.GetSimultaneousRequestsCount()
+	if cnt != 0 {
+		t.Fatalf("requests bucket should be empty, but %d got", cnt)
+	}
+}
+
+func TestConcurrentServeRequestWhenLimitIsReached(t *testing.T) {
+	rObj := RatelimitHandler(10, 2, time.Duration(10*time.Second))
+	rObj.currentMaxRequestsLevel = 2
+	rObj.activeRequestsCount = 1
+	for i := 0; i <= 9; i++ {
+		go func() {
+			req, _ := rObj.ServeRequest(true)
+			time.Sleep(100 * time.Millisecond)
+			rObj.EndRequest(req, endRequestStateOK)
+		}()
+	}
+	time.Sleep(1000 * time.Millisecond)
+	cnt := rObj.GetSimultaneousRequestsCount()
+	if cnt != 1 {
+		t.Fatalf("requests bucket should has one element, but %d got", cnt)
+	}
+}
+
+func TestServeRequestWhenLimitIsReached(t *testing.T) {
+	rObj := RatelimitHandler(10, 2, time.Duration(1*time.Second))
+	rObj.currentMaxRequestsLevel = 2
+	rObj.activeRequestsCount = 1
+
+	req, err := rObj.ServeRequest(true)
+	if err != nil {
+		t.Fatalf("unexpected error occured: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	rObj.EndRequest(req, endRequestStateOK)
+	cnt := rObj.GetSimultaneousRequestsCount()
+
+	if cnt != 1 {
+		t.Fatalf("requests bucket should has one element, but %d got", cnt)
+	}
+}
+
+func TestServeRequestWhenLimitIsReachedShouldReturnAnError(t *testing.T) {
+	rObj := RatelimitHandler(10, 2, time.Duration(100*time.Millisecond))
+	rObj.currentMaxRequestsLevel = 2
+	rObj.activeRequestsCount = 10
+
+	_, err := rObj.ServeRequest(true)
+	if err == nil {
+		t.Fatalf("expected error did not occured")
 	}
 }
 
 func TestEndrequest(t *testing.T) {
 	waitTime := time.Duration(2 * time.Second)
 	rObj := RatelimitHandler(2, 1, waitTime)
-	connID := addRequest(rObj, t)
-	rObj.EndRequest(uuid.NewV4(), endRequestStateOK)
-	if len(rObj.requestsBucket) != 1 {
-		t.Fatal("request should not be deleted form the bucket")
-	}
+
+	req := addRequest(rObj, t)
 	processingTime := time.Duration(100 * time.Millisecond)
 	time.Sleep(processingTime)
-	rObj.EndRequest(connID, endRequestStateOK)
-	if len(rObj.requestsBucket) != 0 {
+	rObj.EndRequest(req, endRequestStateOK)
+	if rObj.GetSimultaneousRequestsCount() != 0 {
 		t.Fatal("request should be deleted form the bucket")
 	}
 	updatedPredicted := rObj.predictedDuration
@@ -63,10 +134,10 @@ func TestEndrequest(t *testing.T) {
 		t.Fatalf("predictedDuration should be decreased, but it is not: was %v, now %v", waitTime, updatedPredicted)
 	}
 
-	connID = addRequest(rObj, t)
+	req = addRequest(rObj, t)
 	time.Sleep(processingTime)
-	rObj.EndRequest(connID, endRequestStateError)
-	if len(rObj.requestsBucket) != 0 {
+	rObj.EndRequest(req, endRequestStateError)
+	if rObj.GetSimultaneousRequestsCount() != 0 {
 		t.Fatal("request should be deleted form the bucket")
 	}
 	if rObj.predictedDuration != updatedPredicted {
@@ -76,73 +147,74 @@ func TestEndrequest(t *testing.T) {
 
 func TestEndrequestWith504(t *testing.T) {
 	waitTime := time.Duration(2 * time.Second)
-	rObj := RatelimitHandler(4, 1, waitTime)
-	connID := addRequest(rObj, t)
+	rObj := RatelimitHandler(5, 1, waitTime)
+	req := addRequest(rObj, t)
 	processingTime := time.Duration(100 * time.Millisecond)
-	time.Sleep(processingTime)
-	rObj.EndRequest(connID, endRequestStateTimedOut)
-	if len(rObj.requestsBucket) != 0 {
+
+	time.Sleep(waitTime + processingTime)
+	rObj.EndRequest(req, endRequestStateCanceled)
+	if rObj.GetSimultaneousRequestsCount() != 0 {
 		t.Fatal("request should be deleted form the bucket")
 	}
-	if rObj.predictedDuration > waitTime {
-		t.Fatal("predictedDuration should be decreased, but it is not")
+	if rObj.predictedDuration < waitTime {
+		t.Fatal("predictedDuration should increase, but it is not")
 	}
-	if rObj.currentMaxRequestsLevel != 1 {
-		t.Fatalf("current max level of bucket should be decreased: %d", rObj.currentMaxRequestsLevel)
-	}
-	connID = addRequest(rObj, t)
-	rObj.EndRequest(connID, endRequestStateOK)
-	if rObj.currentMaxRequestsLevel != 2 {
-		t.Fatalf("current max level of bucket should increase: %d", rObj.currentMaxRequestsLevel)
-	}
-	connID = addRequest(rObj, t)
-	rObj.EndRequest(connID, endRequestStateOK)
 	if rObj.currentMaxRequestsLevel != 3 {
-		t.Fatalf("current max level of bucket should increase: %d", rObj.currentMaxRequestsLevel)
+		t.Fatalf("current max level of bucket should be eq 3: %d", rObj.currentMaxRequestsLevel)
 	}
-	connID = addRequest(rObj, t)
-	rObj.EndRequest(connID, endRequestStateOK)
+	req = addRequest(rObj, t)
+	rObj.EndRequest(req, endRequestStateOK)
 	if rObj.currentMaxRequestsLevel != 4 {
-		t.Fatalf("current max level of bucket should increase: %d", rObj.currentMaxRequestsLevel)
+		t.Fatalf("current max level of bucket should be eq 4: %d", rObj.currentMaxRequestsLevel)
 	}
-	connID = addRequest(rObj, t)
-	rObj.EndRequest(connID, endRequestStateOK)
+	req = addRequest(rObj, t)
+	rObj.EndRequest(req, endRequestStateCanceled)
+	if rObj.currentMaxRequestsLevel != 3 {
+		t.Fatalf("current max level of bucket should be eq 3: %d", rObj.currentMaxRequestsLevel)
+	}
+	req = addRequest(rObj, t)
+	rObj.EndRequest(req, endRequestStateOK)
 	if rObj.currentMaxRequestsLevel != 4 {
-		t.Fatalf("current max level of bucket should not change: %d", rObj.currentMaxRequestsLevel)
+		t.Fatalf("current max level of bucket should be eq 4: %d", rObj.currentMaxRequestsLevel)
+	}
+	req = addRequest(rObj, t)
+	rObj.EndRequest(req, endRequestStateOK)
+	if rObj.currentMaxRequestsLevel != 5 {
+		t.Fatalf("current max level of bucket should be eq 5 (max): %d", rObj.currentMaxRequestsLevel)
 	}
 	addRequest(rObj, t)
-	connID = addRequest(rObj, t)
-	rObj.EndRequest(connID, endRequestStateTimedOut)
-	if rObj.currentMaxRequestsLevel != 2 {
-		t.Fatalf("current max level of bucket should changed to 2, but got: %d", rObj.currentMaxRequestsLevel)
+	req = addRequest(rObj, t)
+	rObj.EndRequest(req, endRequestStateCanceled)
+	if rObj.currentMaxRequestsLevel != 4 {
+		t.Fatalf("current max level of bucket should changed to 4, but got: %d", rObj.currentMaxRequestsLevel)
 	}
 }
 
 func TestServeRequestReturnNoError(t *testing.T) {
 	rObj := RatelimitHandler(2, 1, time.Duration(2*time.Second))
-	connID, err := rObj.ServeRequest()
+	connID, err := rObj.ServeRequest(true)
 	if err != nil {
 		t.Fatalf("error is not expected: %v", err)
 	}
-	if len(rObj.requestsBucket) != 1 {
+	if rObj.GetSimultaneousRequestsCount() != 1 {
 		t.Fatal("request is not in the bucket, when it should be")
 	}
 
 	rObj.EndRequest(connID, endRequestStateOK)
-	if len(rObj.requestsBucket) != 0 {
+	if rObj.GetSimultaneousRequestsCount() != 0 {
 		t.Fatal("request should be deleted")
 	}
 }
 
 func TestServeRequestReturnError(t *testing.T) {
 	rObj := RatelimitHandler(2, 1, time.Duration(100*time.Millisecond))
-	if _, err := rObj.ServeRequest(); err != nil {
+	if _, err := rObj.ServeRequest(true); err != nil {
 		t.Fatalf("we got an unexpected error: %v", err)
 	}
-	if _, err := rObj.ServeRequest(); err != nil {
+	if _, err := rObj.ServeRequest(true); err != nil {
 		t.Fatalf("we got an unexpected error: %v", err)
 	}
-	if _, err := rObj.ServeRequest(); err == nil {
+	if _, err := rObj.ServeRequest(true); err == nil {
 		t.Fatalf("we got an unexpected error: %v", err)
 	}
 }

--- a/graphql/ratelimit_test.go
+++ b/graphql/ratelimit_test.go
@@ -60,7 +60,7 @@ func TestEndrequest(t *testing.T) {
 	}
 	updatedPredicted := rObj.predictedDuration
 	if updatedPredicted >= waitTime {
-		t.Fatal("predictedDuration should be decreased, but it is not")
+		t.Fatalf("predictedDuration should be decreased, but it is not: was %v, now %v", waitTime, updatedPredicted)
 	}
 
 	connID = addRequest(rObj, t)
@@ -120,7 +120,7 @@ func TestEndrequestWith504(t *testing.T) {
 
 func TestServeRequestReturnNoError(t *testing.T) {
 	rObj := RatelimitHandler(2, 1, time.Duration(2*time.Second))
-	connID, err := rObj.ServeRequest(true)
+	connID, err := rObj.ServeRequest()
 	if err != nil {
 		t.Fatalf("error is not expected: %v", err)
 	}
@@ -136,13 +136,13 @@ func TestServeRequestReturnNoError(t *testing.T) {
 
 func TestServeRequestReturnError(t *testing.T) {
 	rObj := RatelimitHandler(2, 1, time.Duration(100*time.Millisecond))
-	if _, err := rObj.ServeRequest(true); err != nil {
+	if _, err := rObj.ServeRequest(); err != nil {
 		t.Fatalf("we got an unexpected error: %v", err)
 	}
-	if _, err := rObj.ServeRequest(true); err != nil {
+	if _, err := rObj.ServeRequest(); err != nil {
 		t.Fatalf("we got an unexpected error: %v", err)
 	}
-	if _, err := rObj.ServeRequest(true); err == nil {
+	if _, err := rObj.ServeRequest(); err == nil {
 		t.Fatalf("we got an unexpected error: %v", err)
 	}
 }

--- a/graphql/ratelimit_test.go
+++ b/graphql/ratelimit_test.go
@@ -1,0 +1,148 @@
+package graphql
+
+import (
+	"testing"
+	"time"
+
+	"github.com/satori/go.uuid"
+)
+
+func addRequest(rObj *RatelimitObject, t *testing.T) uuid.UUID {
+	ID, err := rObj.newRequest()
+	if err != nil {
+		t.Fatalf("error occured, when it was unexpected: %v", err)
+	}
+	if ID == uuid.Nil {
+		t.Fatal("connection ID should not be nil")
+	}
+	return ID
+}
+func TestInitiating(t *testing.T) {
+	rObj := RatelimitHandlerDefault()
+	if rObj.predictedDuration == 0 {
+		t.Fatal("initiate() should set it equal to `waitTime` value")
+	}
+
+	rObj.predictedDuration = time.Duration(10 * time.Second)
+	rObj.initiate()
+
+	if rObj.predictedDuration != time.Duration(10*time.Second) {
+		t.Fatal("initiate() should not update predictedDuration if it has already set")
+	}
+}
+
+func TestNewRequest(t *testing.T) {
+	rObj := RatelimitHandler(10, 2, time.Duration(10*time.Second))
+	addRequest(rObj, t)
+	if cnt := len(rObj.requestsBucket); cnt != 1 {
+		t.Fatalf("requests bucket should has size of 1 element, but %d got", cnt)
+	}
+	addRequest(rObj, t)
+
+	if cnt := len(rObj.requestsBucket); cnt != 2 {
+		t.Fatalf("requests bucket should has size of 1 element, but %d got", cnt)
+	}
+}
+
+func TestEndrequest(t *testing.T) {
+	waitTime := time.Duration(2 * time.Second)
+	rObj := RatelimitHandler(2, 1, waitTime)
+	connID := addRequest(rObj, t)
+	rObj.EndRequest(uuid.NewV4(), endRequestStateOK)
+	if len(rObj.requestsBucket) != 1 {
+		t.Fatal("request should not be deleted form the bucket")
+	}
+	processingTime := time.Duration(100 * time.Millisecond)
+	time.Sleep(processingTime)
+	rObj.EndRequest(connID, endRequestStateOK)
+	if len(rObj.requestsBucket) != 0 {
+		t.Fatal("request should be deleted form the bucket")
+	}
+	updatedPredicted := rObj.predictedDuration
+	if updatedPredicted >= waitTime {
+		t.Fatal("predictedDuration should be decreased, but it is not")
+	}
+
+	connID = addRequest(rObj, t)
+	time.Sleep(processingTime)
+	rObj.EndRequest(connID, endRequestStateError)
+	if len(rObj.requestsBucket) != 0 {
+		t.Fatal("request should be deleted form the bucket")
+	}
+	if rObj.predictedDuration != updatedPredicted {
+		t.Fatal("predictedDuration should not be changed")
+	}
+}
+
+func TestEndrequestWith504(t *testing.T) {
+	waitTime := time.Duration(2 * time.Second)
+	rObj := RatelimitHandler(4, 1, waitTime)
+	connID := addRequest(rObj, t)
+	processingTime := time.Duration(100 * time.Millisecond)
+	time.Sleep(processingTime)
+	rObj.EndRequest(connID, endRequestStateTimedOut)
+	if len(rObj.requestsBucket) != 0 {
+		t.Fatal("request should be deleted form the bucket")
+	}
+	if rObj.predictedDuration > waitTime {
+		t.Fatal("predictedDuration should be decreased, but it is not")
+	}
+	if rObj.currentMaxRequestsLevel != 1 {
+		t.Fatalf("current max level of bucket should be decreased: %d", rObj.currentMaxRequestsLevel)
+	}
+	connID = addRequest(rObj, t)
+	rObj.EndRequest(connID, endRequestStateOK)
+	if rObj.currentMaxRequestsLevel != 2 {
+		t.Fatalf("current max level of bucket should increase: %d", rObj.currentMaxRequestsLevel)
+	}
+	connID = addRequest(rObj, t)
+	rObj.EndRequest(connID, endRequestStateOK)
+	if rObj.currentMaxRequestsLevel != 3 {
+		t.Fatalf("current max level of bucket should increase: %d", rObj.currentMaxRequestsLevel)
+	}
+	connID = addRequest(rObj, t)
+	rObj.EndRequest(connID, endRequestStateOK)
+	if rObj.currentMaxRequestsLevel != 4 {
+		t.Fatalf("current max level of bucket should increase: %d", rObj.currentMaxRequestsLevel)
+	}
+	connID = addRequest(rObj, t)
+	rObj.EndRequest(connID, endRequestStateOK)
+	if rObj.currentMaxRequestsLevel != 4 {
+		t.Fatalf("current max level of bucket should not change: %d", rObj.currentMaxRequestsLevel)
+	}
+	addRequest(rObj, t)
+	connID = addRequest(rObj, t)
+	rObj.EndRequest(connID, endRequestStateTimedOut)
+	if rObj.currentMaxRequestsLevel != 2 {
+		t.Fatalf("current max level of bucket should changed to 2, but got: %d", rObj.currentMaxRequestsLevel)
+	}
+}
+
+func TestServeRequestReturnNoError(t *testing.T) {
+	rObj := RatelimitHandler(2, 1, time.Duration(2*time.Second))
+	connID, err := rObj.ServeRequest(true)
+	if err != nil {
+		t.Fatalf("error is not expected: %v", err)
+	}
+	if len(rObj.requestsBucket) != 1 {
+		t.Fatal("request is not in the bucket, when it should be")
+	}
+
+	rObj.EndRequest(connID, endRequestStateOK)
+	if len(rObj.requestsBucket) != 0 {
+		t.Fatal("request should be deleted")
+	}
+}
+
+func TestServeRequestReturnError(t *testing.T) {
+	rObj := RatelimitHandler(2, 1, time.Duration(100*time.Millisecond))
+	if _, err := rObj.ServeRequest(true); err != nil {
+		t.Fatalf("we got an unexpected error: %v", err)
+	}
+	if _, err := rObj.ServeRequest(true); err != nil {
+		t.Fatalf("we got an unexpected error: %v", err)
+	}
+	if _, err := rObj.ServeRequest(true); err == nil {
+		t.Fatalf("we got an unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
This PR adds ratelimiting of concurrent requests based on query duration time.

The main idea is similar to TCP congestion control algorithms. It adds three params to `HTTPHandlerWithHooks` method for setting hard limits of requests bucket size and max wait time for requests, that came after bucket has reached max level of simultaneous requests.

Algorithm strives to adjust concurrent level based on responses it gets. There are three scenarios:

1.  Everything is fine, request served, and response is gonna be delivered to client. In this case, prediction time for next request will be calculated: if previous predicted time is less than actual - it will set to actual, otherwise, prediction time will be decreased on the half of difference between predicted and actual. Request will be removed from bucket and free space to next one. If current max level of bucket is less than hard limit - it will be incremented by 1.
2. Request got an error during execution - prediction time will not be adjusted. Request will go from bucket.
3. Request was not finished - context was cancelled. Which means that request took too long time to process and something went wrong with Database, or Service. We should decrease the current level of concurrent requests and do free resources for Service, and/or Database. The algorithm will try to set it to the level of requests bucket, that was when the request has been accepted to processing, or, if it greater than current max level - the level will be decreased by 1.

Each time, when request has arrived to Service, there is concurrent level will be checked. If bucket size is on it's current max limit, request will wait for prediction time, if it less than wait time (that was set in `HTTPHandlerWithHooks` method), otherwise, request will be dropped with message `limit is reached...`. After waiting, bucket size will be checked again, and if it has a space for the request, it will be accepted, otherwise - dropped.

Prediction time calculates each time request successfully finished.