### PR TITLE
Remove errorHandler execution usage outside writeResponse function

### DIFF
--- a/graphql/http.go
+++ b/graphql/http.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/reactive"
@@ -21,20 +22,18 @@ func HTTPHandler(schema *Schema, middlewares ...MiddlewareFunc) http.Handler {
 // HTTPHandlerWithHooks works as HTTPHandler
 // but in addition provides passing errorHandler func
 // which will catch errors happened outside middleware
-func HTTPHandlerWithHooks(schema *Schema, errorHandler errorFunc, successfulHandler successfulResponseFunc, middlewares ...MiddlewareFunc) http.Handler {
+func HTTPHandlerWithHooks(schema *Schema, finalHandler finalResponseFunc, middlewares ...MiddlewareFunc) http.Handler {
 	return &httpHandler{
-		schema:            schema,
-		errorHandler:      errorHandler,
-		middlewares:       middlewares,
-		successfulHandler: successfulHandler,
+		schema:       schema,
+		middlewares:  middlewares,
+		finalHandler: finalHandler,
 	}
 }
 
 type httpHandler struct {
-	schema            *Schema
-	errorHandler      errorFunc
-	successfulHandler successfulResponseFunc
-	middlewares       []MiddlewareFunc
+	schema       *Schema
+	finalHandler finalResponseFunc
+	middlewares  []MiddlewareFunc
 }
 
 type httpPostBody struct {
@@ -47,34 +46,49 @@ type httpResponse struct {
 	Errors interface{} `json:"errors"`
 }
 
+// SendError provides sending error message in GraphQL format. It useful in
+// cases when error could be happen outside main logic for serving HTTP
+// requests. The error message has the same pattern as original GraphQL response
+// with HTTP 200 status code. Returns an error, that could be happened during
+// sending data to client
+func SendError(w http.ResponseWriter, message string) error {
+	w.Header().Set("Content-Type", "application/json")
+	_, err := fmt.Fprintf(w, `{"data":null,"errors":[{"message":"%s","path":null,"extensions":{"timestamp":"%s"}}]}`, message, time.Now().UTC())
+	return err
+}
+
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	writeResponse := func(value interface{}, err error, query *string) {
+		var errors []error
+		var responseJSON []byte
+
+		defer h.finalHandler(len(responseJSON), errors, query)
+
 		response := httpResponse{}
 		if err != nil {
-			if h.errorHandler != nil {
-				h.errorHandler(flattenError(err, 0), query)
-			}
+			errors = append(errors, err)
 			response.Errors = []interface{}{newGraphQLError(err)}
 		} else {
 			response.Data = value
 		}
 
-		responseJSON, err := json.Marshal(response)
+		responseJSON, err = json.Marshal(response)
 		if err != nil {
-			if h.errorHandler != nil {
-				h.errorHandler(err, query)
+			errors = append(errors, err)
+			err = SendError(w, newGraphQLError(err).Message)
+			if err != nil {
+				errors = append(errors, err)
 			}
-			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		if w.Header().Get("Content-Type") == "" {
 			w.Header().Set("Content-Type", "application/json")
 		}
 
-		if h.successfulHandler != nil && response.Errors == nil {
-			h.successfulHandler(responseJSON)
+		_, err = w.Write(responseJSON)
+		if err != nil {
+			errors = append(errors, err)
 		}
-		w.Write(responseJSON)
 	}
 
 	if r.Method != "POST" {

--- a/graphql/middleware.go
+++ b/graphql/middleware.go
@@ -21,13 +21,9 @@ type ComputationOutput struct {
 	Error    error
 }
 
-// errorFunc type describes function that will be executed in case if error
-// happens outside processing of MiddlewareFunc
-type errorFunc func(err error, query *string)
-
-// successfulResponseFunc describes function that will be fired before sending
-// successful, non-errored response
-type successfulResponseFunc func(response []byte)
+// finalResponseFunc describes function that will be fired after sending
+// response from writeResponse func
+type finalResponseFunc func(responseLength int, errors []error, query *string)
 type MiddlewareFunc func(input *ComputationInput, next MiddlewareNextFunc) *ComputationOutput
 type MiddlewareNextFunc func(input *ComputationInput) *ComputationOutput
 

--- a/graphql/middleware.go
+++ b/graphql/middleware.go
@@ -21,10 +21,13 @@ type ComputationOutput struct {
 	Error    error
 }
 
-// outsideMiddlewareErrorHandlerFunc type describes function
-// that will be executed in case if error happens outside processing of MiddlewareFunc
-type outsideMiddlewareErrorHandlerFunc func(err error, query *string)
-type responseHook func(response []byte)
+// errorFunc type describes function that will be executed in case if error
+// happens outside processing of MiddlewareFunc
+type errorFunc func(err error, query *string)
+
+// successfulResponseFunc describes function that will be fired before sending
+// successful, non-errored response
+type successfulResponseFunc func(response []byte)
 type MiddlewareFunc func(input *ComputationInput, next MiddlewareNextFunc) *ComputationOutput
 type MiddlewareNextFunc func(input *ComputationInput) *ComputationOutput
 


### PR DESCRIPTION
Hello, for concurrency limiter that performs outside the thunder, we have to control endRequest point. Now we have 2 hooks - successful and error. They works perfectly for this scenario instead of one case: errorHandler could be called twice - when we get malformed request and when we finish processing request with error.

I would like to remove first one, remove logging client error and return it to the client with explaining.

Also just a wish to be more constant with naming - I renamed our hooks according Thunder type names of other middleware.