### PR TITLE
Add descriptions of the fields

### DIFF
--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -135,6 +135,12 @@ func (s *introspection) registerType(schema *schemabuilder.Schema) {
 			return t.Description
 		case *graphql.Union:
 			return t.Description
+		case *graphql.Scalar:
+			return t.Description
+		case *graphql.Enum:
+			return t.Description
+		case *graphql.InputObject:
+			return t.Description
 		default:
 			return ""
 		}
@@ -163,8 +169,9 @@ func (s *introspection) registerType(schema *schemabuilder.Schema) {
 		case *graphql.InputObject:
 			for name, f := range t.InputFields {
 				fields = append(fields, InputValue{
-					Name: name,
-					Type: Type{Inner: f},
+					Name:        name,
+					Description: t.Description,
+					Type:        Type{Inner: f},
 				})
 			}
 		}
@@ -191,9 +198,10 @@ func (s *introspection) registerType(schema *schemabuilder.Schema) {
 				sort.Slice(args, func(i, j int) bool { return args[i].Name < args[j].Name })
 
 				fields = append(fields, field{
-					Name: name,
-					Type: Type{Inner: f.Type},
-					Args: args,
+					Name:        name,
+					Description: f.Description,
+					Type:        Type{Inner: f.Type},
+					Args:        args,
 				})
 			}
 		}

--- a/graphql/schemabuilder/input.go
+++ b/graphql/schemabuilder/input.go
@@ -171,7 +171,7 @@ func (sb *schemaBuilder) makeArgParserInner(typ reflect.Type) (*argParser, graph
 		return parser, argType, nil
 	}
 
-	if parser, argType, ok := getScalarArgParser(typ); ok {
+	if parser, argType, ok := sb.getScalarArgParser(typ); ok {
 		return parser, argType, nil
 	}
 
@@ -310,10 +310,10 @@ func (sb *schemaBuilder) makeSliceParser(typ reflect.Type) (*argParser, graphql.
 }
 
 // getScalarArgParser creates an arg parser for a scalar type.
-func getScalarArgParser(typ reflect.Type) (*argParser, graphql.Type, bool) {
+func (sb *schemaBuilder) getScalarArgParser(typ reflect.Type) (*argParser, graphql.Type, bool) {
 	for match, argParser := range scalarArgParsers {
 		if internal.TypesIdenticalOrScalarAliases(match, typ) {
-			name, ok := getScalar(typ)
+			scalar, ok := sb.getScalar(typ)
 			if !ok {
 				panic(typ)
 			}
@@ -327,7 +327,7 @@ func getScalarArgParser(typ reflect.Type) (*argParser, graphql.Type, bool) {
 				argParser = &newParser
 			}
 
-			return argParser, &graphql.Scalar{Type: name}, true
+			return argParser, scalar, true
 		}
 	}
 	return nil, nil, false

--- a/graphql/schemabuilder/output.go
+++ b/graphql/schemabuilder/output.go
@@ -65,7 +65,7 @@ func (sb *schemaBuilder) buildStruct(typ reflect.Type) error {
 			return fmt.Errorf("bad type %s: two fields named %s", typ, fieldInfo.Name)
 		}
 
-		built, err := sb.buildField(field)
+		built, err := sb.buildField(field, fieldInfo)
 		if err != nil {
 			return fmt.Errorf("bad field %s on type %s: %s", fieldInfo.Name, typ, err)
 		}
@@ -196,7 +196,7 @@ func isScalarType(typ graphql.Type) bool {
 
 // buildField generates a graphQL field for a struct's field.  This field can be
 // used to "resolve" a response for a graphql request.
-func (sb *schemaBuilder) buildField(field reflect.StructField) (*graphql.Field, error) {
+func (sb *schemaBuilder) buildField(field reflect.StructField, fieldInfo *graphQLFieldInfo) (*graphql.Field, error) {
 	retType, err := sb.getType(field.Type)
 	if err != nil {
 		return nil, err
@@ -210,6 +210,7 @@ func (sb *schemaBuilder) buildField(field reflect.StructField) (*graphql.Field, 
 			}
 			return value.FieldByIndex(field.Index).Interface(), nil
 		},
+		Description:    fieldInfo.Description,
 		Type:           retType,
 		ParseArguments: nilParseArguments,
 	}, nil

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -247,7 +247,11 @@ func (c *connectionContext) constructConnectionType(sb *schemaBuilder, typ refle
 	fieldMap := make(map[string]*graphql.Field)
 
 	countType, _ := reflect.TypeOf(Connection{}).FieldByName("TotalCount")
-	countField, err := sb.buildField(countType)
+	countInfo, err := parseGraphQLFieldInfo(countType)
+	if err != nil {
+		return nil, fmt.Errorf("bad type %s: %s", typ, countInfo.Name)
+	}
+	countField, err := sb.buildField(countType, countInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +278,11 @@ func (c *connectionContext) constructConnectionType(sb *schemaBuilder, typ refle
 	fieldMap["edges"] = edgesSliceField
 
 	pageInfoType, _ := reflect.TypeOf(Connection{}).FieldByName("PageInfo")
-	pageInfoField, err := sb.buildField(pageInfoType)
+	pageInfo, err := parseGraphQLFieldInfo(pageInfoType)
+	if err != nil {
+		return nil, fmt.Errorf("bad type %s: %s", typ, pageInfo.Name)
+	}
+	pageInfoField, err := sb.buildField(pageInfoType, pageInfo)
 	pageInfoNonNull, _ := pageInfoField.Type.(*graphql.NonNull)
 	pageInfoObj := pageInfoNonNull.Type.(*graphql.Object)
 

--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -47,6 +47,8 @@ type graphQLFieldInfo struct {
 	// Name is the GraphQL field name that should be exposed for this field.
 	Name string
 
+	Description string
+
 	// KeyField indicates that this field should be treated as a Object Key field.
 	KeyField bool
 
@@ -87,7 +89,12 @@ func parseGraphQLFieldInfo(field reflect.StructField) (*graphQLFieldInfo, error)
 			}
 		}
 	}
-	return &graphQLFieldInfo{Name: name, KeyField: key, OptionalInputField: optional}, nil
+	return &graphQLFieldInfo{
+		Name:               name,
+		KeyField:           key,
+		OptionalInputField: optional,
+		Description:        field.Tag.Get("graphql-description"),
+	}, nil
 }
 
 // Common Types that we will need to perform type assertions against.

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -18,8 +18,9 @@ type Type interface {
 // Scalar is a leaf value.  A custom "Unwrapper" can be attached to the scalar
 // so it can have a custom unwrapping (if nil we will use the default unwrapper).
 type Scalar struct {
-	Type      string
-	Unwrapper func(interface{}) (interface{}, error)
+	Type        string
+	Description string
+	Unwrapper   func(interface{}) (interface{}, error)
 }
 
 func (s *Scalar) isType() {}
@@ -30,9 +31,10 @@ func (s *Scalar) String() string {
 
 // Enum is a leaf value
 type Enum struct {
-	Type       string
-	Values     []string
-	ReverseMap map[interface{}]string
+	Type        string
+	Values      []string
+	Description string
+	ReverseMap  map[interface{}]string
 }
 
 func (e *Enum) isType() {}
@@ -72,6 +74,7 @@ func (l *List) String() string {
 
 type InputObject struct {
 	Name        string
+	Description string
 	InputFields map[string]Type
 }
 
@@ -121,6 +124,7 @@ type Resolver func(ctx context.Context, source, args interface{}, selectionSet *
 //
 // Fields are responsible for computing their value themselves.
 type Field struct {
+	Description    string
 	Resolve        Resolver
 	Type           Type
 	Args           map[string]Type


### PR DESCRIPTION
This commit adds parsing `graphql-description:""` tag in order
to get a description of the field and put it into the answer
of the introspection query.