### PR TITLE
Add a way to check the type of metafield in selectionSet

### DIFF
--- a/graphql/end_to_end_test.go
+++ b/graphql/end_to_end_test.go
@@ -79,13 +79,9 @@ func TestPathError(t *testing.T) {
 
 	e = graphql.Executor{}
 	_, err = e.Execute(context.Background(), builtSchema.Query, nil, q)
-	if err == nil || err.Error() != "safe safe" {
+	if err == nil || err.Error() != "safe: safe safe" {
 		t.Errorf("bad error: %v", err)
 	}
-	if _, ok := err.(graphql.SanitizedError); !ok {
-		t.Errorf("safe not safe")
-	}
-
 }
 
 func TestEnum(t *testing.T) {

--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -166,7 +166,7 @@ func PrepareQuery(typ Type, selectionSet *SelectionSet) error {
 			}
 		}
 		for _, selection := range selectionSet.Selections {
-			if selection.Name == "__typename" {
+			if selection.MetaFieldType() == MetaFieldTypeName {
 				if !isNilArgs(selection.Args) {
 					return NewClientError(`error parsing args for "__typename": no args expected`)
 				}
@@ -183,7 +183,7 @@ func PrepareQuery(typ Type, selectionSet *SelectionSet) error {
 			return NewClientError("object field must have selections")
 		}
 		for _, selection := range selectionSet.Selections {
-			if selection.Name == "__typename" {
+			if selection.MetaFieldType() == MetaFieldTypeName {
 				if !isNilArgs(selection.Args) {
 					return NewClientError(`error parsing args for "__typename": no args expected`)
 				}
@@ -315,7 +315,7 @@ func (e *Executor) executeUnion(ctx context.Context, typ *Union, source interfac
 
 	fields := make(map[string]interface{})
 	for _, selection := range selectionSet.Selections {
-		if selection.Name == "__typename" {
+		if selection.MetaFieldType() == MetaFieldTypeName {
 			fields[selection.Alias] = typ.Name
 			continue
 		}
@@ -370,7 +370,7 @@ func (e *Executor) executeObject(ctx context.Context, typ *Object, source interf
 
 	// for every selection, resolve the value and store it in the output object
 	for _, selection := range selections {
-		if selection.Name == "__typename" {
+		if selection.MetaFieldType() == MetaFieldTypeName {
 			fields[selection.Alias] = typ.Name
 			continue
 		}

--- a/graphql/http_test.go
+++ b/graphql/http_test.go
@@ -24,7 +24,8 @@ func testHTTPRequest(req *http.Request) *httptest.ResponseRecorder {
 	builtSchema := schema.MustBuild()
 
 	rr := httptest.NewRecorder()
-	handler := graphql.HTTPHandler(builtSchema)
+	finalHandler := func(responseLength int, errors []error, query *string) {}
+	handler := graphql.HTTPHandlerWithHooks(builtSchema, finalHandler)
 
 	handler.ServeHTTP(rr, req)
 	return rr

--- a/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
+++ b/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
@@ -867,7 +867,7 @@
               "possibleTypes": []
             },
             {
-              "description": "",
+              "description": "Scalar type bool",
               "enumValues": [],
               "fields": [],
               "inputFields": [],
@@ -906,7 +906,7 @@
               "possibleTypes": []
             },
             {
-              "description": "",
+              "description": "Scalar type int64",
               "enumValues": [],
               "fields": [],
               "inputFields": [],
@@ -916,7 +916,7 @@
               "possibleTypes": []
             },
             {
-              "description": "",
+              "description": "Scalar type string",
               "enumValues": [],
               "fields": [],
               "inputFields": [],

--- a/graphql/schemabuilder/build.go
+++ b/graphql/schemabuilder/build.go
@@ -95,9 +95,14 @@ func (sb *schemaBuilder) getType(nodeType reflect.Type) (graphql.Type, error) {
 // encoding.TextMarshaler and convert it's value into a string in the graphQL
 // response.
 func (sb *schemaBuilder) getTextMarshalerType(typ reflect.Type) (graphql.Type, error) {
+	obj := sb.objects[typ]
+	var description string
+	if obj != nil {
+		description = obj.Description
+	}
 	scalar := &graphql.Scalar{
 		Type:        "string",
-		Description: sb.objects[typ].Description,
+		Description: description,
 		Unwrapper: func(source interface{}) (interface{}, error) {
 			i := reflect.ValueOf(source)
 			if i.Kind() == reflect.Ptr && i.IsNil() {

--- a/graphql/testdata/TestConnection.snapshots.json
+++ b/graphql/testdata/TestConnection.snapshots.json
@@ -181,7 +181,7 @@
     "Name": "Pagination, with ctx and error",
     "Values": [
       {
-        "Error": "this is an error"
+        "Error": "inner.innerConnectionWithError: this is an error"
       }
     ]
   },
@@ -189,7 +189,7 @@
     "Name": "Pagination, with error",
     "Values": [
       {
-        "Error": "this is an error"
+        "Error": "inner.innerConnectionWithError: this is an error"
       }
     ]
   },
@@ -197,7 +197,7 @@
     "Name": "Pagination, with error",
     "Values": [
       {
-        "Error": "first/last cannot be a negative integer"
+        "Error": "inner.innerConnection: first/last cannot be a negative integer"
       }
     ]
   },

--- a/graphql/testdata/TestTextMarshaling.snapshots.json
+++ b/graphql/testdata/TestTextMarshaling.snapshots.json
@@ -35,7 +35,7 @@
     "Name": "invalid ptr uuid input",
     "Values": [
       {
-        "Error": "error parsing args for \"inner\": inputPtrUuid: uuid: incorrect UUID length: invaliduuid"
+        "Error": "error parsing args for \"inner\": inputPtrUuid: uuid: invalid UUID string: invaliduuid"
       }
     ]
   },
@@ -43,7 +43,7 @@
     "Name": "invalid uuid input",
     "Values": [
       {
-        "Error": "error parsing args for \"inner\": inputUuid: uuid: incorrect UUID length: invaliduuid"
+        "Error": "error parsing args for \"inner\": inputUuid: uuid: invalid UUID string: invaliduuid"
       }
     ]
   },
@@ -51,7 +51,7 @@
     "Name": "invalid uuid slice input",
     "Values": [
       {
-        "Error": "error parsing args for \"inner\": inputUuidSlice: uuid: incorrect UUID length: invaliduuid"
+        "Error": "error parsing args for \"inner\": inputUuidSlice: uuid: invalid UUID string: invaliduuid"
       }
     ]
   },

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 // Type represents a GraphQL type, and should be either an Object, a Scalar,
@@ -181,6 +182,33 @@ type Selection struct {
 	// The parsed flag is used to make sure the args for this Selection are only
 	// parsed once.
 	parsed bool
+}
+
+// MetaFieldType a type of meta fields
+type MetaFieldType int32
+
+const (
+	// NotMetaField is regular field, which has name without "__" prefix
+	NotMetaField MetaFieldType = iota
+	// MetaFieldOther a field with "__" prefix
+	MetaFieldOther
+	// MetaFieldTypeName is stands for "__typename"
+	MetaFieldTypeName
+)
+
+// MetaFieldType returns type of meta field (assume all fields with names which
+// starts with "__" are meta fields), i.e. "__typename" will result with
+// MetaFieldTypeName
+func (selection Selection) MetaFieldType() MetaFieldType {
+	switch selection.Name {
+	case "__typename":
+		return MetaFieldTypeName
+	default:
+		if strings.HasPrefix(selection.Name, "__") {
+			return MetaFieldOther
+		}
+		return NotMetaField
+	}
 }
 
 // A Fragment represents a reusable part of a GraphQL query

--- a/sqlgen/example_test.go
+++ b/sqlgen/example_test.go
@@ -56,7 +56,7 @@ func Example_tagOverride() {
 	schema.MustRegisterType("users", sqlgen.UniqueId, User{})
 
 	db := sqlgen.NewDB(testDb.DB, schema)
-	uuid, _ := uuid.NewV4()
+	uuid := uuid.NewV4()
 
 	initialUser := &User{
 		UUID: UUID(uuid),             // => BINARY (via uuid.MarshalBinary())


### PR DESCRIPTION
This commit adds a method `MetaFieldType()` which will returns a
meta field type (basically, fields with prefix "__" are meta-fields).
Currently supported one specific meta-field type for __typename.

This commit also adds an extra check during reading `Description` attribute
of the one of objects in the map to prevent panics with nil pointer
exception.

This commit also updates tests according to recent changes inside
introspection and error reporting.