### PR TITLE
Proxy request's context to finalHandler

### DIFF
--- a/graphql/http_test.go
+++ b/graphql/http_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -24,7 +25,7 @@ func testHTTPRequest(req *http.Request) *httptest.ResponseRecorder {
 	builtSchema := schema.MustBuild()
 
 	rr := httptest.NewRecorder()
-	finalHandler := func(responseLength int, errors []error, query *string) {}
+	finalHandler := func(ctx context.Context, responseLength int, errors []error, query *string) {}
 	handler := graphql.HTTPHandlerWithHooks(builtSchema, finalHandler)
 
 	handler.ServeHTTP(rr, req)

--- a/graphql/middleware.go
+++ b/graphql/middleware.go
@@ -23,7 +23,7 @@ type ComputationOutput struct {
 
 // finalResponseFunc describes function that will be fired after sending
 // response from writeResponse func
-type finalResponseFunc func(responseLength int, errors []error, query *string)
+type finalResponseFunc func(ctx context.Context, responseLength int, errors []error, query *string)
 type MiddlewareFunc func(input *ComputationInput, next MiddlewareNextFunc) *ComputationOutput
 type MiddlewareNextFunc func(input *ComputationInput) *ComputationOutput
 


### PR DESCRIPTION
This PR adds request's context to `finalHandler` in order to have an ability to dig into context params for further logging inside `finalHandler`.