### PR TITLE
Add access to meta data about client error

### DIFF
--- a/graphql/http.go
+++ b/graphql/http.go
@@ -138,23 +138,23 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			output.Current, output.Error = e.Execute(input.Ctx, schema, nil, input.ParsedQuery)
 			return output
 		})
-
-		output := RunMiddlewares(middlewares, &ComputationInput{
+		input := &ComputationInput{
 			Ctx:         ctx,
 			ParsedQuery: query,
 			Query:       params.Query,
 			Variables:   params.Variables,
-		})
+		}
+		output := RunMiddlewares(middlewares, input)
 		current, err := output.Current, output.Error
 
 		if err != nil {
 			if ErrorCause(err) != context.Canceled {
-				writeResponse(ctx, nil, err, &params.Query)
+				writeResponse(input.Ctx, nil, err, &params.Query)
 			}
 			return nil, err
 		}
 
-		writeResponse(ctx, current, nil, nil)
+		writeResponse(input.Ctx, current, nil, nil)
 		return nil, nil
 	}, DefaultMinRerunInterval)
 

--- a/graphql/server.go
+++ b/graphql/server.go
@@ -117,6 +117,11 @@ func (e ClientError) SanitizedError() string {
 	return e.message
 }
 
+// Code returns meta data about occurred client error
+func (e ClientError) Code() string {
+	return e.code
+}
+
 func (e SafeError) Error() string {
 	return e.message
 }


### PR DESCRIPTION
We have a possibility to set meta information about the error.
However, for some reasons we don't have ability to read it directly.
This commit adds getter for `code` attribute of `ClientError`.

This commit also updates the context provided to writeResponse()
method. Now it respects any updates of the context made by
middleware functions.